### PR TITLE
Feat/compiler patcher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+venv
 
 # Unit test / coverage reports
 htmlcov/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+
+test:
+#? Run test suite
+	@cd tests && pytest

--- a/tests/alembic.ini
+++ b/tests/alembic.ini
@@ -49,7 +49,9 @@ prepend_sys_path = .
 # version_path_separator = :
 # version_path_separator = ;
 # version_path_separator = space
-version_path_separator = os  # Use os.pathsep. Default configuration used for new projects.
+
+# Use os.pathsep. Default configuration used for new projects.
+version_path_separator = os
 
 # the output encoding used when revision files
 # are written from script.py.mako

--- a/tests/async/conftest.py
+++ b/tests/async/conftest.py
@@ -7,7 +7,8 @@ from tests.models import Base, DATABASE_URL
 @pytest_asyncio.fixture
 def async_engine():
     yield create_async_engine(
-        DATABASE_URL.set(drivername='timescaledb+asyncpg')
+        DATABASE_URL.set(drivername='timescaledb+asyncpg'),
+		echo=True
     )
 
 

--- a/tests/async/test_hypertable.py
+++ b/tests/async/test_hypertable.py
@@ -27,3 +27,4 @@ class TestHypertable:
                 """
             )
         )).scalar_one()
+        #assert False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,7 @@ register(MetricFactory)
 
 @pytest.fixture
 def engine():
-    yield create_engine(DATABASE_URL)
+    yield create_engine(DATABASE_URL, echo=True)
 
 
 @pytest.fixture
@@ -20,9 +20,13 @@ def session(engine):
         yield session
 
 
+_factory_session = None
+
 @pytest.fixture(autouse=True)
 def setup(engine):
-    FactorySession.configure(bind=engine)
+    global _factory_session
+    if _factory_session is None:
+        _factory_session = FactorySession.configure(bind=engine)
     Base.metadata.create_all(bind=engine)
     yield
     Base.metadata.drop_all(bind=engine)

--- a/tests/models.py
+++ b/tests/models.py
@@ -6,11 +6,11 @@ from sqlalchemy.engine import URL
 from sqlalchemy.orm import declarative_base
 
 DATABASE_URL = URL.create(
-    host=os.environ.get('POSTGRES_HOST', '0.0.0.0'),
+    host=os.environ.get('POSTGRES_HOST', 'localhost'),
     port=os.environ.get('POSTGRES_PORT', 5432),
-    username=os.environ.get('POSTGRES_USER', 'user'),
+    username=os.environ.get('POSTGRES_USER', 'postgres'),
     password=os.environ.get('POSTGRES_PASSWORD', 'password'),
-    database=os.environ.get('POSTGRES_DB', 'database'),
+    database=os.environ.get('POSTGRES_DB', 'test_timescaledb'),
     drivername=os.environ.get('DRIVERNAME', 'timescaledb')
 )
 

--- a/tests/test_alembic.py
+++ b/tests/test_alembic.py
@@ -16,6 +16,7 @@ class TestAlembic:
         self.migration_versions_path = os.path.join(
             os.path.dirname(__file__), 'migrations', 'versions'
         )
+        self.config.set_main_option("version_locations",self.migration_versions_path)
 
     def test_create_revision(self, engine):
         Base.metadata.drop_all(bind=engine)


### PR DESCRIPTION
This PR patches postgresql-specific compilers so that they are also used for timescaledb. See the comment in `patch_postgres_compilers` for a more detailed explanation of what's going on here.